### PR TITLE
fix(allocate): correct allocation with a zero ratio item

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -182,6 +182,9 @@ class Money {
             remainder -= share;
         });
         for (let i = 0; remainder > 0; i++) {
+            while (results[i].amount === 0) {
+                i++;
+            }
             results[i] = new Money(results[i].amount + 1, results[i].currency);
             remainder--;
         }

--- a/index.ts
+++ b/index.ts
@@ -232,6 +232,9 @@ class Money {
         })
 
         for (let i = 0; remainder > 0; i++) {
+            while(results[i].amount === 0) {
+                i++
+            }
             results[i] = new Money(results[i].amount + 1, results[i].currency)
             remainder--
         }

--- a/test/money.test.js
+++ b/test/money.test.js
@@ -234,6 +234,19 @@ describe('Money', function () {
        expect(results[2].currency).to.equal('EUR');
     });
 
+    it('should allocate correctly with a zero rate', function() {
+       var subject = new Money(29900, Money.EUR);
+       var results = subject.allocate([265.09, 0, 33.91]);
+
+       expect(results.length).to.equal(3);
+       expect(results[0].amount).to.equal(26509);
+       expect(results[0].currency).to.equal('EUR');
+       expect(results[1].amount).to.equal(0);
+       expect(results[1].currency).to.equal('EUR');
+       expect(results[2].amount).to.equal(3391);
+       expect(results[2].currency).to.equal('EUR');
+    });
+
     it('zero check works correctly', function() {
         var subject = new Money(1000, 'EUR');
         var subject1 = new Money(0, 'EUR');


### PR DESCRIPTION
```
const results = new Money(29900, Money.EUR).allocate([265.09, 0, 33.91]).map(money => money.toDecimal());
// returns [265.09, 0.01, 33.9] instead of [265.09, 0.00, 33.91]
```